### PR TITLE
Rename entrypoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ ignore = [
     "PLR0912", # Too many branches
     "PLR0913", # Too many arguments in function definition
     "PLR0915", # Too many statements
+    "PLC0415", # `import` should be at the top-level of a file
 ]
 
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,8 +123,8 @@ where = ["src"]
 
 [project.entry-points.'nomad.plugin']
 
-general_schema = "pdi_nomad_plugin.general:schema"
-characterization_schema = "pdi_nomad_plugin.characterization:schema"
+general_schema = "pdi_nomad_plugin.general:schema_entry_point"
+characterization_schema = "pdi_nomad_plugin.characterization:schema_entry_point"
 materials_schema = "pdi_nomad_plugin.mbe:materials_schema"
 instrument_schema = "pdi_nomad_plugin.mbe:instrument_schema"
 processes_schema = "pdi_nomad_plugin.mbe:processes_schema"

--- a/src/pdi_nomad_plugin/characterization/__init__.py
+++ b/src/pdi_nomad_plugin/characterization/__init__.py
@@ -28,7 +28,7 @@ class CharacterizationSchemaPackageEntryPoint(SchemaPackageEntryPoint):
         return m_package
 
 
-schema = CharacterizationSchemaPackageEntryPoint(
+schema_entry_point = CharacterizationSchemaPackageEntryPoint(
     name='CharacterizationSchema',
     description='Schema package defined using the new plugin mechanism.',
 )

--- a/src/pdi_nomad_plugin/general/__init__.py
+++ b/src/pdi_nomad_plugin/general/__init__.py
@@ -11,7 +11,7 @@ class GeneralPackageEntryPoint(SchemaPackageEntryPoint):
         return m_package
 
 
-schema = GeneralPackageEntryPoint(
+schema_entry_point = GeneralPackageEntryPoint(
     name='GeneralSchema',
     description='Schema package defined using the new plugin mechanism.',
 )


### PR DESCRIPTION
- [x] Rename entrypoints to avoid confusion with `pdi_nomad_plugin.*.schema` module