### PR TITLE
Reset parent's parent after copying the parent

### DIFF
--- a/src/pdi_nomad_plugin/general/schema.py
+++ b/src/pdi_nomad_plugin/general/schema.py
@@ -441,6 +441,7 @@ class SampleCutPDI(ProcessPDI, Process, EntryData):
         generated_samples = []
         if self.parent_sample and self.number_of_samples:
             children_object = self.parent_sample.reference.m_copy(deep=False)
+            children_object.parent_sample = None
             if self.children_geometry:
                 children_object.geometry = self.children_geometry
             else:


### PR DESCRIPTION
Resetting the parent sub-section completely so that lab-id and name of the immediate parent assigned later based on the immediate parent reference.