### PR TITLE
Handling `merge_sections` for different sections

### DIFF
--- a/src/pdi_nomad_plugin/utils.py
+++ b/src/pdi_nomad_plugin/utils.py
@@ -759,12 +759,12 @@ def merge_sections(  # noqa: PLR0912
             f'Cannot merge "{type(section)}" with "{type(update)}" as they are not of '
             'the same type and do not have a common ancestry.'
         )
-    for name, quantity in update.m_def.all_quantities.items():
-        if not update.m_is_set(quantity):
+    for name, _ in update.m_def.all_quantities.items():
+        if not update.m_is_set(name):
             continue
-        if not section.m_is_set(quantity):
-            section.m_set(quantity, update.m_get(quantity))
-        elif _not_equal(section.m_get(quantity), update.m_get(quantity)):
+        if not section.m_is_set(name):
+            section.m_set(name, update.m_get(name))
+        elif _not_equal(section.m_get(name), update.m_get(name)):
             warning = f'Merging sections with different values for quantity "{name}".'
             if logger:
                 logger.warning(warning)

--- a/src/pdi_nomad_plugin/utils.py
+++ b/src/pdi_nomad_plugin/utils.py
@@ -760,7 +760,7 @@ def merge_sections(  # noqa: PLR0912
             'the same type and do not have a common ancestry.'
         )
     for name, _ in update.m_def.all_quantities.items():
-        if not update.m_is_set(name):
+        if not update.m_is_set(name) or name not in section.m_def.all_quantities:
             continue
         if not section.m_is_set(name):
             section.m_set(name, update.m_get(name))


### PR DESCRIPTION
`merge_section` allows merging two different sections with same ancestry. However, when merging a quantity, it uses `m_def` of the quantity, instead of the quantity name. Quantity `m_def` is different for the two sections even for quantities with same name. 

For example, `m_def` for `lab_id` for `AnnealingPDI` and `AnnealingRecipePDI` will be `nomad.datamodel.metainfo.basesections.v1.BaseSection.lab_id` and 
`nomad_material_processing.general.AnnealingRecipe.lab_id` respectively.

Instead of using the `m_def`, this PR changes to using quantity name, which is consistent across children sections. Additionally, we add a check to only populate a quantity in the target section, if it's definition is found.